### PR TITLE
use optional chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
-const safeGet = require('just-safe-get')
-
 function tableify(items, options) {
   if (!items) return undefined
 
   let html = '<table>'
   let headers = []
 
-  if (!safeGet(options, 'headers') || !Array.isArray(options.headers)) {
+  if (!Array.isArray(options?.headers)) {
     // get unique keys of all objects
     headers = new Set()
     items.forEach(item => {
@@ -38,7 +36,7 @@ function tableify(items, options) {
         let cell = '<th'
         const currentHeader = typeof header === 'object' ? header.field : header
 
-        if (safeGet(options, 'headerCellClass')) {
+        if (options?.headerCellClass) {
           const customClass = options.headerCellClass(headers, currentHeader)
           if (typeof customClass === 'string') cell += ` class="${customClass}"`
         }
@@ -46,7 +44,7 @@ function tableify(items, options) {
         cell += '>'
 
         let content = header
-        if (safeGet(options, 'headerCellContent')) {
+        if (options?.headerCellContent) {
           const customContent = options.headerCellContent(
             headers,
             currentHeader
@@ -63,7 +61,7 @@ function tableify(items, options) {
 
   const tableBody = items
     .map(item => {
-      if (safeGet(options, 'hideRow') && options.hideRow(item)) return '' // skip row
+      if (options?.hideRow?.(item)) return '' // skip row
 
       const row = headers
         .map(header => {
@@ -78,7 +76,7 @@ function tableify(items, options) {
           const currentHeader =
             typeof header === 'object' ? header.field : header
 
-          if (safeGet(options, 'bodyCellClass')) {
+          if (options?.bodyCellClass) {
             const customClass = options.bodyCellClass(
               item,
               currentHeader,
@@ -91,7 +89,7 @@ function tableify(items, options) {
           cell += '>'
 
           let content = item[currentHeader] || ''
-          if (safeGet(options, 'bodyCellContent')) {
+          if (options?.bodyCellContent) {
             const customContent = options.bodyCellContent(
               item,
               currentHeader,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4154,11 +4154,6 @@
         "array-includes": "^3.0.3"
       }
     },
-    "just-safe-get": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/just-safe-get/-/just-safe-get-1.3.0.tgz",
-      "integrity": "sha512-HpKrvuHv1sZuG8aV5w2X9bl8Di0mT9sE836Vj3UZ/IDR/XxynWWAoCH4aLyeXSlRpmRnAzRmyPh2PDUpDpW6Dg=="
-    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4157,8 +4157,7 @@
     "just-safe-get": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/just-safe-get/-/just-safe-get-1.3.0.tgz",
-      "integrity": "sha512-HpKrvuHv1sZuG8aV5w2X9bl8Di0mT9sE836Vj3UZ/IDR/XxynWWAoCH4aLyeXSlRpmRnAzRmyPh2PDUpDpW6Dg==",
-      "dev": true
+      "integrity": "sha512-HpKrvuHv1sZuG8aV5w2X9bl8Di0mT9sE836Vj3UZ/IDR/XxynWWAoCH4aLyeXSlRpmRnAzRmyPh2PDUpDpW6Dg=="
     },
     "kind-of": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "tillhub/tableify",
   "main": "index.js",
   "engines": {
-    "node": ">=8",
+    "node": ">=14",
     "npm": ">=5"
   },
   "scripts": {
@@ -62,9 +62,7 @@
     "package-lock.json",
     "CHANGELOG.md"
   ],
-  "dependencies": {
-    "just-safe-get": "^1.3.0"
-  },
+  "dependencies": {},
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "file": "^0.2.2",
     "gh-pages": "^1.2.0",
     "glob": "^7.1.3",
-    "just-safe-get": "^1.3.0",
     "loader": "^2.1.1",
     "oneline": "^1.0.0",
     "path": "^0.12.7",
@@ -63,7 +62,9 @@
     "package-lock.json",
     "CHANGELOG.md"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "just-safe-get": "^1.3.0"
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
this PR uses the new JS feature optional chaining ([MDN refrance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)) instead of requiring `just-safe-get`

fixes #2
closes #3